### PR TITLE
Correct misnamed terms for lifetime to "period"

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ curl -F 'file=@foo.png' http://our-server.example/
 # Burn after reading:
 curl -F 'file=@foo.png' -F 'burn=1' http://our-server.example/
 
-# Set a custom expiry date, e.g., one day:
+# Set a custom expiry period, e.g., one day:
 curl -F 'file=@foo.png' -F 'time=1d' http://our-server.example/
 
 # Or all together:

--- a/internal/item.go
+++ b/internal/item.go
@@ -18,7 +18,7 @@ import (
 const (
 	formFile             string = "file"
 	formBurnAfterReading string = "burn"
-	formLifetime         string = "time"
+	formLifetime         string = "period"
 )
 
 // OwnerType describes a possible type of an owner, as an IP address. This can

--- a/internal/server.go
+++ b/internal/server.go
@@ -108,13 +108,13 @@ const indexTpl = `<!DOCTYPE html>
 
 		<pre>$ curl -F 'file=@foo.png' -F 'burn=1' {{.Proto}}://{{.Hostname}}/</pre>
 
-		Set a custom expiry date, e.g., one minute:
+		Set a custom expiry period, e.g., one minute:
 
-		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' {{.Proto}}://{{.Hostname}}/</pre>
+		<pre>$ curl -F 'file=@foo.png' -F 'period=1m' {{.Proto}}://{{.Hostname}}/</pre>
 
 		Or all together:
 
-		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' -F 'burn=1' {{.Proto}}://{{.Hostname}}/</pre>
+		<pre>$ curl -F 'file=@foo.png' -F 'period=1m' -F 'burn=1' {{.Proto}}://{{.Hostname}}/</pre>
 
 		Print only URL as response:
 
@@ -131,10 +131,10 @@ const indexTpl = `<!DOCTYPE html>
 				<input type="file" name="file" />
 				<label for="burn">Burn after reading:</label>
 				<input type="checkbox" name="burn" value="1" />
-				<label for="time">Optionally, set a custom expiry date:</label>
+				<label for="period">Optionally, set a custom expiry period:</label>
 				<input
 					type="text"
-					name="time"
+					name="period"
 					pattern="{{.DurationPattern}}"
 					title="A duration string is sequence of decimal numbers, each with a unit suffix. Valid time units in order are 'y', 'mo', 'w', 'd', 'h', 'm', 's'"
 				/>


### PR DESCRIPTION
This draft PR corrects terms for the lifetime that formerly where namend inconsistently "time" or "date". It introduces "period" as replacement.

Please note, this commit is not fully tested. I tried to, but the build failed. Please check carefully.