### PR TITLE
Move template into file tree to allow templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Types of changes:
 ## [Unreleased]
 ### Added
 - URL prefix support to host, e.g., under `http://example.org/gosh/`
-- Add goshy as bash script and NixOS program, [@riotbibt](https://github.com/riotbib) in [#27](https://github.com/oxzi/gosh/pull/27).
+- Add goshy as bash script and NixOS program, [@riotbib](https://github.com/riotbib) in [#27](https://github.com/oxzi/gosh/pull/27).
 - Created Store RPC working on Unix domain sockets to allow a `fork`+`exec`ed daemon.
 - Configuration through YAML configuration file.
 
@@ -30,6 +30,7 @@ Types of changes:
 - `goshd` became `gosh`.
 - Made `gosh` a `chroot`ed, privilege dropped, `fork`+`exec`ed daemon.
 - OpenBSD installation changed due to structural program changes.
+- Extract web template into a more editable file, [@riotbib](https://github.com/riotbib) in [#45](https://github.com/oxzi/gosh/pull/45).
 
 ### Deprecated
 ### Removed

--- a/index.html
+++ b/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>gosh! Go Share</title>
+
+		<style>
+			* {
+				font-family: monospace;
+			}
+
+			body {
+				margin: 0 auto;
+				padding: 1rem;
+				width: 50%;
+			}
+
+			h1 {
+				padding-top: 3rem;
+			}
+
+			h2 {
+				padding-top: 2rem;
+			}
+
+			h3 {
+				padding-top: 1rem;
+			}
+
+			pre {
+				background-color: #eee;
+				padding: 0.5rem;
+			}
+
+			form {
+				padding: 0.5rem;
+				position: relative;
+				margin: auto;
+				background-color: #eee;
+			}
+
+			#grid {
+				display: grid;
+				grid-gap: 1rem;
+				grid-template-columns: 1fr 1fr;
+				grid-template-rows: repeat(3, 3rem);
+				margin-bottom: 1rem;
+			}
+
+			#grid > * {
+				margin: auto 0;
+			}
+
+			#grid input[type="checkbox"] {
+				margin-right: auto;
+			}
+
+			button {
+				width: 100%;
+			}
+		</style>
+	</head>
+
+	<body>
+		<h1># gosh! Go Share</h1>
+		<p>
+			Upload your files to this server and share them with your friends or, if
+			non-existent, shady people from the Internet.
+		</p>
+		<p>
+			Your file will expire after {{.Expires}} or earlier, if explicitly
+			specified. Optionally, the file can be deleted directly after the first
+			retrieval. For each upload, a deletion URL will also be generated which
+			can be used to delete the file before expiration. In addition, the
+			maximum file size is {{.Size}}.
+		</p>
+		<p>
+			This is no place to share questionable or illegal data. Please use another
+			service or stop it completely. Get some help.
+		</p>
+		<p>
+			The gosh software can be obtained from
+			<a href="https://github.com/oxzi/gosh">https://github.com/oxzi/gosh</a>
+		</p>
+
+		<h2>## Posting</h2>
+
+		<h3>### curl</h3>
+
+		HTTP POST your file:
+
+		<pre>$ curl -F 'file=@foo.png' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
+
+		Burn after reading:
+
+		<pre>$ curl -F 'file=@foo.png' -F 'burn=1' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
+
+		Set a custom expiry date, e.g., one minute:
+
+		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
+
+		Or all together:
+
+		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' -F 'burn=1' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
+
+		Print only URL as response:
+
+		<pre>$ curl -F 'file=@foo.png' -F {{.Proto}}://{{.Hostname}}{{.Prefix}}/?onlyURL</pre>
+
+		<h3>### form</h3>
+
+		<form
+			action="{{.Proto}}://{{.Hostname}}{{.Prefix}}/"
+			method="POST"
+			enctype="multipart/form-data">
+			<div id="grid">
+				<label for="file">Your file:</label>
+				<input type="file" name="file" />
+				<label for="burn">Burn after reading:</label>
+				<input type="checkbox" name="burn" value="1" />
+				<label for="time">Optionally, set a custom expiry date:</label>
+				<input
+					type="text"
+					name="time"
+					pattern="{{.DurationPattern}}"
+					title="A duration string is sequence of decimal numbers, each with a unit suffix. Valid time units in order are 'y', 'mo', 'w', 'd', 'h', 'm', 's'"
+				/>
+			</div>
+			<button>Upload</button>
+		</form>
+
+		<h2>## Privacy</h2>
+
+		This software stores the IP address for each upload. This information is
+		stored as long as the file is available. A normal download is logged without
+		user information.
+
+		<h2>## Abuse</h2>
+
+		If, for whatever reason, you would like to have a file removed prematurely,
+		please write an e-mail to
+		<a href="mailto:{{.EMail}}">&lt;{{.EMail}}&gt;</a>. Please allow me a
+		certain amount of time to react and work on your request.
+	</body>
+</html>

--- a/webserver.go
+++ b/webserver.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
+	"html/template"
 	"io"
 	"net"
 	"net/http"
 	"net/http/fcgi"
 	"os"
 	"strings"
-	"html/template"
 	"time"
+
+	_ "embed"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/webserver.go
+++ b/webserver.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"io"
 	"net"
@@ -9,157 +10,14 @@ import (
 	"net/http/fcgi"
 	"os"
 	"strings"
-	"text/template"
+	"html/template"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
 
-const indexTpl = `<!DOCTYPE html>
-<html>
-	<head>
-		<title>gosh! Go Share</title>
-
-		<style>
-			* {
-				font-family: monospace;
-			}
-
-			body {
-				margin: 0 auto;
-				padding: 1rem;
-				width: 50%;
-			}
-
-			h1 {
-				padding-top: 3rem;
-			}
-
-			h2 {
-				padding-top: 2rem;
-			}
-
-			h3 {
-				padding-top: 1rem;
-			}
-
-			pre {
-				background-color: #eee;
-				padding: 0.5rem;
-			}
-
-			form {
-				padding: 0.5rem;
-				position: relative;
-				margin: auto;
-				background-color: #eee;
-			}
-
-			#grid {
-				display: grid;
-				grid-gap: 1rem;
-				grid-template-columns: 1fr 1fr;
-				grid-template-rows: repeat(3, 3rem);
-				margin-bottom: 1rem;
-			}
-
-			#grid > * {
-				margin: auto 0;
-			}
-
-			#grid input[type="checkbox"] {
-				margin-right: auto;
-			}
-
-			button {
-				width: 100%;
-			}
-		</style>
-	</head>
-
-	<body>
-		<h1># gosh! Go Share</h1>
-		<p>
-			Upload your files to this server and share them with your friends or, if
-			non-existent, shady people from the Internet.
-		</p>
-		<p>
-			Your file will expire after {{.Expires}} or earlier, if explicitly
-			specified. Optionally, the file can be deleted directly after the first
-			retrieval. For each upload, a deletion URL will also be generated which
-			can be used to delete the file before expiration. In addition, the
-			maximum file size is {{.Size}}.
-		</p>
-		<p>
-			This is no place to share questionable or illegal data. Please use another
-			service or stop it completely. Get some help.
-		</p>
-		<p>
-			The gosh software can be obtained from
-			<a href="https://github.com/oxzi/gosh">https://github.com/oxzi/gosh</a>
-		</p>
-
-		<h2>## Posting</h2>
-
-		<h3>### curl</h3>
-
-		HTTP POST your file:
-
-		<pre>$ curl -F 'file=@foo.png' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
-
-		Burn after reading:
-
-		<pre>$ curl -F 'file=@foo.png' -F 'burn=1' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
-
-		Set a custom expiry date, e.g., one minute:
-
-		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
-
-		Or all together:
-
-		<pre>$ curl -F 'file=@foo.png' -F 'time=1m' -F 'burn=1' {{.Proto}}://{{.Hostname}}{{.Prefix}}/</pre>
-
-		Print only URL as response:
-
-		<pre>$ curl -F 'file=@foo.png' -F {{.Proto}}://{{.Hostname}}{{.Prefix}}/?onlyURL</pre>
-
-		<h3>### form</h3>
-
-		<form
-			action="{{.Proto}}://{{.Hostname}}{{.Prefix}}/"
-			method="POST"
-			enctype="multipart/form-data">
-			<div id="grid">
-				<label for="file">Your file:</label>
-				<input type="file" name="file" />
-				<label for="burn">Burn after reading:</label>
-				<input type="checkbox" name="burn" value="1" />
-				<label for="time">Optionally, set a custom expiry date:</label>
-				<input
-					type="text"
-					name="time"
-					pattern="{{.DurationPattern}}"
-					title="A duration string is sequence of decimal numbers, each with a unit suffix. Valid time units in order are 'y', 'mo', 'w', 'd', 'h', 'm', 's'"
-				/>
-			</div>
-			<button>Upload</button>
-		</form>
-
-		<h2>## Privacy</h2>
-
-		This software stores the IP address for each upload. This information is
-		stored as long as the file is available. A normal download is logged without
-		user information.
-
-		<h2>## Abuse</h2>
-
-		If, for whatever reason, you would like to have a file removed prematurely,
-		please write an e-mail to
-		<a href="mailto:{{.EMail}}">&lt;{{.EMail}}&gt;</a>. Please allow me a
-		certain amount of time to react and work on your request.
-	</body>
-</html>
-`
+//go:embed index.html
+var indexTpl string
 
 const (
 	msgDeletionKeyWrong  = "Error: Deletion key is incorrect."


### PR DESCRIPTION
This commit changes how the indexTpl variable is handled. Now an index.html sourced from the file tree is embedded into the binary.

This allows changing the HTML for the index page more easily.

Closes #31.