### PR TITLE
contrib: Add MIME type check and flag for goshy

### DIFF
--- a/contrib/bash/goshy
+++ b/contrib/bash/goshy
@@ -7,6 +7,7 @@ Options:
   -b --burn              Burn after reading.
   -h --help              Print this help message.
   -i --instance          Complete URL to the gosh instance.
+  -m --mime-type         Set file's MIME type, otherwise guessed.
   -p --period TIMEFRAME  Set a custom expiry period.
   -u --only-url          Print only URL as response.
   -q --qr-code           Print only QR code as response.
@@ -26,6 +27,11 @@ while :; do
 
     -i|--instance)
       GOSH_INSTANCE="$2"
+      shift
+      ;;
+
+    -m|--mime-type)
+      MIMETYPE="$2"
       shift
       ;;
 
@@ -60,7 +66,12 @@ if [ -z "$GOSH_INSTANCE" ]; then
   exit 1
 fi
 
-CURL_CMD="curl -s -F 'file=@${FILE}'"
+if [[ -n ${MIMETYPE} ]]; then
+  CURL_MIMETYPE=";type=${MIMETYPE}"
+else
+  CURL_MIMETYPE=";type=$(file --mime-type ${FILE} | awk '{print $NF}')"
+fi
+CURL_CMD="curl -s -F 'file=@${FILE}${CURL_MIMETYPE}'"
 if [[ -n ${BURN+x} ]]; then
   CURL_CMD="${CURL_CMD} -F 'burn=1'"
 fi

--- a/contrib/nixos/goshy.nix
+++ b/contrib/nixos/goshy.nix
@@ -10,13 +10,13 @@ let
 
     src = ../../.;
 
-    buildInputs = [ pkgs.bash pkgs.curl ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
 
     installPhase = ''
       mkdir -p $out/bin
       cp ./contrib/bash/goshy $out/bin/goshy
       wrapProgram $out/bin/goshy \
+        --prefix PATH : ${lib.makeBinPath [ pkgs.bash pkgs.curl pkgs.file pkgs.gawk pkgs.qrencode ]} \
         --set GOSH_INSTANCE "${cfg.instance}" \
         --set PERIOD "${cfg.expiryPeriod}" \
         ${lib.optionalString cfg.burnAfterReading "--set BURN 1"} \


### PR DESCRIPTION
Without this information added to curl's POST request some browsers like Firefox don't display `video/mp4` inside the app, but want to download the video.

If the flag is not used manually, goshy now guesses the MIME type.

This adds `file` and `gawk` as dependencies for goshy.

While adding those to the NixOS module I noticed that `buildInputs` didn't add the deps to the PATH; but passing those to `wrapProgram` worked. Since `bash` and `curl` are installed by default on NixOS, I guess this was never noticed.

Also added `qrencode` as dep for goshy on NixOS packaging.